### PR TITLE
librespot and snapcast updates

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "librespot-git"]
 	path = librespot-git
-	url = https://github.com/plietar/librespot.git
+	url = https://github.com/kingosticks/librespot.git

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN apt-get -qq update &&\
         supervisor bzip2 portaudio19-dev libvorbisfile3 curl libprotoc-dev cargo &&\
 
 # Snapcast, Shairport-sync,avahi and dbus
-    curl -L -o /root/out.deb 'https://github.com/badaix/snapcast/releases/download/v0.11.1/snapserver_0.11.1_amd64.deb' &&\
+    curl -L -o /root/out.deb 'https://github.com/badaix/snapcast/releases/download/v0.12.0/snapserver_0.12.0_amd64.deb' &&\
     dpkg -i --force-all /root/out.deb &&\
     apt-get -y -f install &&\
     mkdir -p /root/.config/snapcast/ &&\

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,12 +2,14 @@ version: "2"
 
 services:
    multiroomaudio:
-        image: s1lvester/docker-snapcast-multiroomaudio
-     
-        networks:
-            mylan:
-                ipv4_address: # desired address for container e.g. 192.168.5.80
+     image: s1lvester/docker-snapcast-multiroomaudio
+     environment:
+       SPOTIFY_BITRATE: 160
+       ENV_SPOTIFY_NAME: Snapcast
+     networks:
+       mylan:
+         ipv4_address: # desired address for container e.g. 192.168.5.80
      
 networks:
-    mylan:
-        external: true
+  mylan:
+    external: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
      image: s1lvester/docker-snapcast-multiroomaudio
      environment:
        SPOTIFY_BITRATE: 160
-       ENV_SPOTIFY_NAME: Snapcast
+       SPOTIFY_NAME: Snapcast
      networks:
        mylan:
          ipv4_address: # desired address for container e.g. 192.168.5.80

--- a/start.sh
+++ b/start.sh
@@ -1,4 +1,7 @@
 #! /bin/sh
+# set defaults
+export ENV_SPOTIFY_NAME="${ENV_SPOTIFY_NAME:=Snapcast}"
+export ENV_SPOTIFY_BITRATE="${ENV_SPOTIFY_BITRATE:=160}"
 
 # setup dbus
 rm -rf /var/run/dbus

--- a/start.sh
+++ b/start.sh
@@ -1,7 +1,7 @@
 #! /bin/sh
 # set defaults
-export ENV_SPOTIFY_NAME="${ENV_SPOTIFY_NAME:=Snapcast}"
-export ENV_SPOTIFY_BITRATE="${ENV_SPOTIFY_BITRATE:=160}"
+export SPOTIFY_NAME="${SPOTIFY_NAME:=Snapcast}"
+export SPOTIFY_BITRATE="${SPOTIFY_BITRATE:=160}"
 
 # setup dbus
 rm -rf /var/run/dbus

--- a/start.sh
+++ b/start.sh
@@ -4,8 +4,7 @@ export SPOTIFY_NAME="${SPOTIFY_NAME:=Snapcast}"
 export SPOTIFY_BITRATE="${SPOTIFY_BITRATE:=160}"
 
 # setup dbus
-rm -rf /var/run/dbus
-mkdir -p /var/run/dbus
+rm -rf /var/run/dbus || mkdir -p /var/run/dbus
 chown -R messagebus:messagebus /var/run/dbus
 dbus-uuidgen --ensure
 dbus-daemon --system --fork

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -10,7 +10,7 @@ command=avahi-daemon --no-drop-root
 
 [program:snapserver]
 ;command=snapserver --stream=pipe:///tmp/snapfifo?name=MultiRoomAudio --pipeReadBuffer=100 --buffer=1500 --codec=ogg --sampleformat=44100:16:2
-command=snapserver -s "spotify:///usr/local/bin/librespot?name=Spotify" -s "airplay:///usr/bin/shairport-sync?name=Airplay"
+command=snapserver -s "spotify:///usr/local/bin/librespot?name=Spotify&devicename=%(ENV_SPOTIFY_NAME)s&bitrate=%(ENV_SPOTIFY_BITRATE)s" -s "airplay:///usr/bin/shairport-sync?name=Airplay"
 ;stdout_logfile=/dev/null
 ;stderr_logfile=/dev/null
 


### PR DESCRIPTION
 * updated snapserver to 0.12.0
 * updated librespot with new build

librespot has recently been abandoned so I switched the submodule to use the fork that seemed to have the most activity. This fork added shuffle and repeat support. Something we should keep an eye on as a leader emerges amongst the forks.